### PR TITLE
Add CI using PlatformIO

### DIFF
--- a/.github/workflows/platformio-ci.yaml
+++ b/.github/workflows/platformio-ci.yaml
@@ -1,0 +1,41 @@
+name: PlatformIO CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v2
+
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v2
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+
+      - name: Run build
+        run: pio run


### PR DESCRIPTION
Hi Clemens and Andreas,

this will automatically run the build on GitHub Actions on all push events as well as pull requests.
Thus, it will improve confidence for the authors regarding all further contributions.

See also: https://docs.platformio.org/en/latest/integration/ci/github-actions.html

With kind regards,
Andreas.