### PR TITLE
Update library versions

### DIFF
--- a/hani-mandl.ino
+++ b/hani-mandl.ino
@@ -80,10 +80,10 @@
 
 #include <Arduino.h>
 #include <Wire.h>
-#include <U8g2lib.h>      /* aus dem Bibliotheksverwalter */
-#include <HX711.h>        /* aus dem Bibliotheksverwalter */
-#include <ESP32_Servo.h>  /* https://github.com/jkb-git/ESP32Servo */
-#include <Preferences.h>  /* aus dem BSP von expressif, wird verfügbar wenn das richtige Board ausgewählt ist */
+#include <U8g2lib.h>      /* Aus dem Arduino Bibliotheksverwalter */
+#include <HX711.h>        /* Aus dem Arduino Bibliotheksverwalter */
+#include <ESP32Servo.h>   /* Aus dem Arduino Bibliotheksverwalter */
+#include <Preferences.h>  /* Aus dem BSP von expressif, wird verfügbar wenn das richtige Board ausgewählt ist */
 
 //
 // Hier den Code auf die verwendete Hardware einstellen
@@ -1967,7 +1967,7 @@ void setup()
 #ifdef SERVO_ERWEITERT
   servo.attach(servo_pin, 750, 2500);  // erweiterte Initialisierung, steuert nicht jeden Servo an
 #else
-  servo.attach(servo_pin);             // default Werte. Achtung, steuert den Nullpunkt weniger weit aus!  
+  servo.attach(servo_pin, 1000, 2000); // default Werte. Achtung, steuert den Nullpunkt weniger weit aus!
 #endif
   SERVO_WRITE(winkel_min);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,4 +21,4 @@ monitor_speed = 115200
 lib_deps =
     HX711@^0.7.4
     U8g2@^2.28.6
-    https://github.com/jkb-git/ESP32Servo
+    ESP32Servo@^0.9.0


### PR DESCRIPTION
Hi Clemens and Andreas,

this uses the most recent versions of the U8g2 and ESP32Servo libraries.

Both libraries are well maintained by their respective authors and maintainers, so we should use them in favour of outdated libraries which are no longer maintained.

A little adjustment has been made to one #include statement. The updated library header file is now called `ESP32Servo.h` instead of `ESP32_Servo.h`.

This also corresponds with 8e605aa5 by @andreash-esp.

With kind regards,
Andreas.