### PR TITLE
Add badges for PlatformIO CI and GitHub tag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,7 @@
-# HaniMandl 
+![image](https://github.com/ClemensGruber/hani-mandl/workflows/PlatformIO%20CI/badge.svg)
+![image](https://img.shields.io/github/v/tag/ClemensGruber/hani-mandl.svg)
+
+# HaniMandl
 
 Ein halbautomatischer Honig-Abfüll-Roboter.
 


### PR DESCRIPTION
Hi Clemens,

this adds two badges to the top of the README file.

- A PlatformIO CI badge to show that the build is passing successfully, as a followup to #16.
- A GitHub tag badge to show the most recent release version tag.

With kind regards,
Andreas.

![image](https://user-images.githubusercontent.com/453543/104033594-08f12180-51d0-11eb-988a-a05852bb6681.png)
