### PR TITLE
Adjust pin definition for Heltec WiFi LoRa 32 V1/V2 boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ $(eval python       := $(venvpath)/bin/python)
 $(eval pip          := $(venvpath)/bin/pip)
 $(eval platformio   := $(venvpath)/bin/platformio)
 
+.PHONY: build test
+
 
 build: setup-virtualenv
 	$(platformio) run

--- a/hani-mandl.ino
+++ b/hani-mandl.ino
@@ -176,14 +176,24 @@ U8G2_SSD1306_128X64_NONAME_F_SW_I2C u8g2(U8G2_R0, /* clock=*/ 15, /* data=*/ 4, 
 //U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/ 16, /* clock=*/ 15, /* data=*/ 4);   // HW I2C crashed den Code
 
 // Rotary Encoder
+#if defined(ARDUINO_HELTEC_WIFI_KIT_32)
 const int outputA  = 33;
 const int outputB  = 26;
 const int outputSW = 32;
+
+#elif defined(ARDUINO_HELTEC_WIFI_LORA_32) || defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+const int outputA  = 33;
+const int outputB  = 39;
+const int outputSW = 32;
+#endif
+
 
 // Servo
 const int servo_pin = 2;
 
 // 3x Schalter Ein 1 - Aus - Ein 2
+#if defined(ARDUINO_HELTEC_WIFI_KIT_32)
+
 #ifdef HARDWARE_LAYOUT_LEGACY
 const int switch_betrieb_pin = 19;
 const int switch_vcc_pin     = 22;     // <- Vcc
@@ -195,6 +205,14 @@ const int switch_setup_pin   = 22;
 const int vext_ctrl_pin      = 21;     // Vext control pin
 #endif
 
+#elif defined(ARDUINO_HELTEC_WIFI_LORA_32) || defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+const int switch_betrieb_pin = 23;
+const int switch_vcc_pin     = 16;     // <- Vcc
+const int switch_setup_pin   = 22;
+const int vext_ctrl_pin      = 21;     // Vext control pin
+#endif
+
+
 // Taster
 const int button_start_vcc_pin = 13;  // <- Vcc
 const int button_start_pin     = 12;
@@ -205,8 +223,14 @@ const int button_stop_pin      = 27;
 const int poti_pin = 39;
 
 // Wägezelle-IC
+#if defined(ARDUINO_HELTEC_WIFI_KIT_32)
 const int hx711_sck_pin = 17;
 const int hx711_dt_pin  = 5;
+
+#elif defined(ARDUINO_HELTEC_WIFI_LORA_32) || defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+const int hx711_sck_pin = 17;
+const int hx711_dt_pin  = 2;
+#endif
 
 // Buzzer - aktiver Piezo
 static int buzzer_pin = 25;

--- a/hani-mandl.ino
+++ b/hani-mandl.ino
@@ -94,21 +94,41 @@
 //
 // Hier den Code auf die verwendete Hardware einstellen
 //
-#define HARDWARE_LEVEL 2        // 1 = originales Layout mit Schalter auf Pin 19/22/21
-                                // 2 = Layout für V2 mit Schalter auf Pin 23/19/22
-#define SERVO_ERWEITERT         // definieren, falls die Hardware mit dem alten Programmcode mit Poti aufgebaut wurde oder der Servo zu wenig fährt
+
+// Wird normalerweise durch die Umgebung (Arduino/PlatformIO) vorgegeben.
+// #define ARDUINO_HELTEC_WIFI_KIT_32
+// #define ARDUINO_HELTEC_WIFI_LORA_32
+// #define ARDUINO_HELTEC_WIFI_LORA_32_V2
+
+#define SERVO_ERWEITERT         // Definieren, falls die Hardware mit dem alten Programmcode mit Poti aufgebaut wurde oder der Servo zu wenig fährt
                                 // Sonst bleibt der Servo in Stop-Position einige Grad offen! Nach dem Update erst prüfen!
-#define ROTARY_SCALE 2          // in welchen Schritten springt unser Rotary Encoder.
-                                // Beispiele: KY-040 = 2, HW-040 = 1, für Poti-Betrieb auf 1 setzen
 #define USE_ROTARY              // Rotary benutzen
 #define USE_ROTARY_SW           // Taster des Rotary benutzen
+#define ROTARY_SCALE 2          // In welchen Schritten springt der Rotary Encoder.
+                                // Beispiele: KY-040 = 2, HW-040 = 1, für Poti-Betrieb auf 1 setzen
 //#define USE_POTI              // Poti benutzen -> ACHTUNG, im Normalfall auch USE_ROTARY_SW deaktivieren!
 //#define FEHLERKORREKTUR_WAAGE   // falls Gewichtssprünge auftreten, können diese hier abgefangen werden
                                 // Achtung, kann den Wägeprozess verlangsamen. Vorher Hardware prüfen.
 //#define QUETSCHHAHN_LINKS       // Servo invertieren, falls der Quetschhahn von links geöffnet wird. Mindestens ein Exemplar bekannt
+//#define HARDWARE_LAYOUT_LEGACY  // Frueheres Hardware-Layout mit Schalter auf Pin 19/22/21
+
 //
 // Ende Benutzereinstellungen!
 //
+
+
+// Sanity checks
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#pragma message "Board-Variante: " STR(ARDUINO_VARIANT)
+#if not( \
+  defined(ARDUINO_HELTEC_WIFI_KIT_32) || \
+  defined(ARDUINO_HELTEC_WIFI_LORA_32) || \
+  defined(ARDUINO_HELTEC_WIFI_LORA_32_V2) \
+  )
+#error Board-Variante nicht implementiert. Bitte korrektes #define setzen!
+#endif
 
 //
 // Ab hier nur verstellen wenn Du genau weisst, was Du tust!
@@ -164,17 +184,15 @@ const int outputSW = 32;
 const int servo_pin = 2;
 
 // 3x Schalter Ein 1 - Aus - Ein 2
-#if HARDWARE_LEVEL == 1
+#ifdef HARDWARE_LAYOUT_LEGACY
 const int switch_betrieb_pin = 19;
 const int switch_vcc_pin     = 22;     // <- Vcc
 const int switch_setup_pin   = 21;
-#elif HARDWARE_LEVEL == 2
+#else
 const int switch_betrieb_pin = 23;
 const int switch_vcc_pin     = 19;     // <- Vcc
 const int switch_setup_pin   = 22;
 const int vext_ctrl_pin      = 21;     // Vext control pin
-#else
-#error Hardware Level nicht definiert! Korrektes #define setzen!
 #endif
 
 // Taster
@@ -1941,7 +1959,7 @@ void setup()
   pinMode(button_stop_pin, INPUT_PULLDOWN);
   pinMode(switch_betrieb_pin, INPUT_PULLDOWN);
   pinMode(switch_setup_pin, INPUT_PULLDOWN);
-#if HARDWARE_LEVEL == 2
+#ifndef HARDWARE_LAYOUT_LEGACY
   pinMode(vext_ctrl_pin, INPUT_PULLDOWN);
 #endif
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,14 +11,29 @@
 [platformio]
 src_dir = .
 
-[env:heltec]
+
+; Global data for all [env:***]
+[env]
 platform = espressif32
-board = heltec_wifi_kit_32
 framework = arduino
 
-monitor_speed = 115200
+src_filter =
+    +<*>
+    -<test/>
 
 lib_deps =
     HX711@^0.7.4
     U8g2@^2.28.6
     ESP32Servo@^0.9.0
+
+monitor_speed = 115200
+
+
+[env:heltec_wifi_kit_32]
+board = heltec_wifi_kit_32
+
+[env:heltec_wifi_lora_32]
+board = heltec_wifi_lora_32
+
+[env:heltec_wifi_lora_32_V2]
+board = heltec_wifi_lora_32_V2

--- a/readme.md
+++ b/readme.md
@@ -18,9 +18,8 @@ Websites:
 Das Verhalten des Codes wird über mehrere `#define`-Variablen gesteuert.
 
 ```
-#define HARDWARE_LEVEL 2
-  1 für originales pinout Layout mit Schalter auf Pin 19/22/21
-  2 für neues Layout für "New Heltec Wifi Kit 32" (V2) mit Schalter auf Pin 23/19/22
+#define HARDWARE_LAYOUT_LEGACY
+  Fuer das fruehere Hardware-Layout mit Schalter auf Pin 19/22/21 aktivieren.
 
 #define SERVO_ERWEITERT
   aktivieren, falls ein Automat mit Software 0.1.4 aktualisiert wird und der Servo nicht ganz schliesst
@@ -57,9 +56,16 @@ Die weiteren defines und Variablen müssen bei einer Standard-Schaltung nicht an
 
 ## Hardware-Aufbau
 
+### Verkabelung
+
+Aktuell liegt der Schalter auf Pin 23/19/22. Bei einem frueheren Layout lag er auf Pin 19/22/21.
+
+
+### Hinweise
 Es wird empfohlen, den Servo erst nach dem ersten Einschalten der Elektronik mit dem Quetschhahn zu verbinden!
 Der Servo fährt automatisch in die Nullstellung. Danach kann das Gestänge verbunden werden und über das Servo-Setup
 können die Servo-Positionen fein eingestellt werden.
+
 
 ## Betrieb
 
@@ -80,7 +86,7 @@ Für jede Füllmenge bzw. das entsprechende Glas kann ein Leergewicht ("Tara") d
 Die hinterlegten Tara-Werte werden im Menu angezeigt.
 Einstellung: Füllmenge wählen, leeres Glas aufstellen und über die Auswahl-Taste speichern
 
-2. Kalibieren
+2. Kalibrieren
 Menügeführte Kalibrierung der Wägezelle
 
 3. Korrektur
@@ -185,30 +191,44 @@ im Abfüllbehälter nach. Das Zielgewicht wird im Automatik-Setup über die Kula
 
 ## Firmware bauen
 
-Just type:
-```
+Fuer die Erstellung einer Firmware passend zum [Heltec WiFi Kit 32], einfach nur:
+```bash
 make
 ```
 
-After successfully building it, you will find firmware images at
+Nach erfolgreichem Kompilieren sind die Firmware-Dateien hier zu finden:
 
-- .pio/build/heltec/firmware.bin
-- .pio/build/heltec/firmware.elf
+- .pio/build/heltec_wifi_kit_32/firmware.bin
+- .pio/build/heltec_wifi_kit_32/firmware.elf
+
+### Andere Boards
+
+Diese Firmware unterstuetzt neben dem [Heltec WiFi Kit 32] auch das
+[Heltec WiFi LoRa 32] sowie das [Heltec WiFi LoRa 32 (V2)].
+
+```bash
+source .venv/bin/activate
+pio run --environment=heltec_wifi_kit_32
+pio run --environment=heltec_wifi_lora_32
+pio run --environment=heltec_wifi_lora_32_V2
+```
+
+[Heltec WiFi Kit 32]: https://docs.platformio.org/en/latest/boards/espressif32/heltec_wifi_kit_32.html
+[Heltec WiFi LoRa 32]: https://docs.platformio.org/en/latest/boards/espressif32/heltec_wifi_lora_32.html
+[Heltec WiFi LoRa 32 (V2)]: https://docs.platformio.org/en/latest/boards/espressif32/heltec_wifi_lora_32_V2.html
 
 
 ## Binär-Datei `hani-mandl.bin`
 
-Die Datei `hani-mandl.bin` wurde mit folgenden Parametern für das Board Heltec ESP32 Arduino > Wifi Kit 32 compiliert:
+Die Datei `hani-mandl.bin` wurde mit folgenden Parametern für das Board [Heltec WiFi Kit 32] kompiliert:
 
 ```
-#define HARDWARE_LEVEL 2        // 1 = originales Layout mit Schalter auf Pin 19/22/21
-                                // 2 = Layout für V2 mit Schalter auf Pin 23/19/22
-#define SERVO_ERWEITERT         // definieren, falls die Hardware mit dem alten Programmcode mit Poti aufgebaut wurde oder der Servo zu wenig fährt
+#define SERVO_ERWEITERT         // Definieren, falls die Hardware mit dem alten Programmcode mit Poti aufgebaut wurde oder der Servo zu wenig fährt
                                 // Sonst bleibt der Servo in Stop-Position einige Grad offen! Nach dem Update erst prüfen!
-#define ROTARY_SCALE 2          // in welchen Schritten springt unser Rotary Encoder.
-                                // Beispiele: KY-040 = 2, HW-040 = 1, für Poti-Betrieb auf 1 setzen
 #define USE_ROTARY              // Rotary benutzen
 #define USE_ROTARY_SW           // Taster des Rotary benutzen
+#define ROTARY_SCALE 2          // In welchen Schritten springt der Rotary Encoder.
+                                // Beispiele: KY-040 = 2, HW-040 = 1, für Poti-Betrieb auf 1 setzen
 ```
 
 Eine Anleitung zum Flashen der Binär-Datei gibt es unter


### PR DESCRIPTION
Hi again,

following up on the patch #15 by @SBajonczak (thanks!), I've added this patch based on the recent improvements coming from #21. This currently does not discriminate between _Heltec WiFi LoRa 32_ vs. _Heltec WiFi LoRa 32 V2_ boards. When there are changes, we will have to account for appropriate adjustments.

With kind regards,
Andreas.
