### PR TITLE
fixed #32 crashing program when using rotary encoder 

### DIFF
--- a/hani-mandl.ino
+++ b/hani-mandl.ino
@@ -75,6 +75,8 @@
                                  Servo-defaults für die neue Bibliothek angepasst
   2021-01 Andreas Motl       | Version 0.2.9.1
                                - PlatformIO-Support an neue Servo-Bibliothek angepasst
+  2022-08 Johannes Arndt     | Version 0.2.9.2
+                               - PlatformIO-Support fuer espressif32 bei Version 3.5.0 eingeforen 
 
 
   This code is in the public domain.

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env:heltec]
-platform = espressif32
+platform = espressif32@^3.5.0
 board = heltec_wifi_kit_32
 framework = arduino
 


### PR DESCRIPTION
by freezing version of espressif to 3.5.0

Espressif 3.5.0 is the last version working without crashing. When I tried 4.0.0 or higher, the program crashed when using the rotary encoder.