### PR TITLE
CI: Add support for "Arduino core for the ESP32" version 2.0.6

### DIFF
--- a/.github/workflows/platformio-ci.yaml
+++ b/.github/workflows/platformio-ci.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -24,13 +24,15 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache PlatformIO
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.platformio
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Install PlatformIO
         run: |

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,14 +11,24 @@
 [platformio]
 src_dir = .
 
-[env:heltec]
-platform = espressif32
-board = heltec_wifi_kit_32
-framework = arduino
-
+[env]
 monitor_speed = 115200
 
 lib_deps =
     HX711@^0.7.4
     U8g2@^2.28.6
     ESP32Servo@^0.9.0
+
+[env:heltec-arduino-esp32-1.0.6]
+platform = espressif32
+board = heltec_wifi_kit_32
+framework = arduino
+platform_packages =
+  platformio/framework-arduinoespressif32@3.10006.210326
+
+[env:heltec-arduino-esp32-2.0.6]
+platform = espressif32
+board = heltec_wifi_kit_32
+framework = arduino
+platform_packages =
+  platformio/framework-arduinoespressif32@3.20006.221224


### PR DESCRIPTION
Dear Clemens,

I can confirm your observations reported at [^1]. This patch adds support for _"Arduino core for the ESP32" version 2.0.6_ to CI/GHA, and it currently fails.

- https://github.com/espressif/arduino-esp32/tree/2.0.6
- https://registry.platformio.org/tools/platformio/framework-arduinoespressif32/versions

With kind regards,
Andreas.

[^1]: https://community.hiveeyes.org/t/kann-ich-auch-das-heltec-wifi-kit-32-in-der-neuen-version-v3-verwenden/4696/23